### PR TITLE
Fix/stored event checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This changelog references the relevant changes done between versions.
 To get the diff for a specific change, go to https://github.com/LIN3S/SharedKernel/commit/XXX where XXX is the change hash 
 To get the diff between two versions, go to https://github.com/LIN3S/SharedKernel/compare/v0.8.0...v0.9.0
 
+* 0.9.7
+   * Allow to an event object to contain an array
 * 0.9.6
    * Added `nationalPhone` in the Phone value object.
 * 0.9.5

--- a/src/LIN3S/SharedKernel/Event/StoredEvent.php
+++ b/src/LIN3S/SharedKernel/Event/StoredEvent.php
@@ -110,7 +110,7 @@ class StoredEvent implements \JsonSerializable
     {
         $property->setAccessible(true);
         $value = $property->getValue($object);
-        if (null === $value || is_scalar($value)) {
+        if (null === $value || is_scalar($value) || is_array($value)) {
             return $value;
         }
 


### PR DESCRIPTION
An Event Object could not hold an Object with an array as a property (e. g.: collection objects).