### PR TITLE
Made tactician event subscriber definitions public to avoid Symfony 4 issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This changelog references the relevant changes done between versions.
 To get the diff for a specific change, go to https://github.com/LIN3S/SharedKernel/commit/XXX where XXX is the change hash 
 To get the diff between two versions, go to https://github.com/LIN3S/SharedKernel/compare/v0.8.0...v0.9.0
 
+* 0.9.8
+   * Made tactician event subscriber definitions public to avoid Symfony 4 issues
 * 0.9.7
    * Allow to an event object to contain an array
 * 0.9.6

--- a/src/LIN3S/SharedKernel/Infrastructure/Symfony/Bundle/DependencyInjection/Compiler/TacticianEventsBusPass.php
+++ b/src/LIN3S/SharedKernel/Infrastructure/Symfony/Bundle/DependencyInjection/Compiler/TacticianEventsBusPass.php
@@ -79,7 +79,9 @@ class TacticianEventsBusPass implements CompilerPassInterface
                         TacticianEventSubscriber::class,
                         [new Reference($id)]
                     )
-                )->addTag('tactician.event_listener', ['event' => $attributes['subscribes_to']]);
+                )
+                    ->setPublic(true)		
+                    ->addTag('tactician.event_listener', ['event' => $attributes['subscribes_to']]);
             }
         }
     }


### PR DESCRIPTION
Internally somehow event subscribers are called directly from the container. In symfony 4 the following error is thrown during container processing:

```
The "tactician_event_subscriber.FormManager\Domain\Event\Integration\NotifyForm
  RecordSubmittedWhenFormRecordWasSubmitted_0" service or alias has been removed
  or inlined when the container was compiled. You should either make it public, o
  r stop using the container directly and use dependency injection instead.
```